### PR TITLE
Fixing a couple of broken links

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -96,10 +96,10 @@
       <div id="sidebar" class="span4">
         <h4>Get started</h4>
         <ul>
-          <li><a rel="external" href="{{baseURL}}/install">Install Kanso tools</a></li>
-          <li><a rel="external" href="http://kan.so/docs/">Get started creating apps</a></li>
-          <li><a rel="external" href="http://kan.so/docs/Publishing_Packages">Share code with the community</a></li>
-          <li><a rel="external" href="{{baseURL}}/packages">Browse the package repository</a></li>
+          <li><a href="{{baseURL}}/install">Install Kanso tools</a></li>
+          <li><a href="{{baseURL}}/docs/">Get started creating apps</a></li>
+          <li><a href="{{baseURL}}/docs/Publishing_Packages">Share code with the community</a></li>
+          <li><a href="{{baseURL}}/packages">Browse the package repository</a></li>
           <li><a rel="external" href="http://github.com/kanso/kanso">Watch the project on GitHub</a></li>
         </ul>
 


### PR DESCRIPTION
Fixing a couple of broken links that still pointed to the old kan.so url and also removed  rel="external" from the ones that weren't actually external.